### PR TITLE
Increase timeout for darwin nix builds to 30min

### DIFF
--- a/nix/metal/bitteProfile/darwin/guests/modules/basics.nix
+++ b/nix/metal/bitteProfile/darwin/guests/modules/basics.nix
@@ -60,7 +60,7 @@ in {
       timeout = ${toString (3600 * 8)}
 
       # Quickly kill stuck builds
-      max-silent-time = ${toString (60 * 15)}
+      max-silent-time = ${toString (60 * 30)}
       sandbox = false
       extra-sandbox-paths = /System/Library/Frameworks /usr/lib /System/Library/PrivateFrameworks
       experimental-features = nix-command flakes


### PR DESCRIPTION
 as we got lot of timeouts for valid builds on mithril (rustc not being
 very verbose)